### PR TITLE
only trigger ci on main or pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 env:
   CARGO_TERM_COLOR: always
 jobs:


### PR DESCRIPTION
to avoid extra builds and make use of the base branch cache.